### PR TITLE
append mode for -o flag (ignore fields) in dump command

### DIFF
--- a/messages/dump.json
+++ b/messages/dump.json
@@ -6,8 +6,7 @@
   "idmapFlagDescription": "idmap.json file path, to REVERSE map IDs from",
   "fileFlagDescription": "relative/full path to file to write CSV into",
   "sobjecttypeFlagDescription": "The sObject type of the records you want to dump.",
-  "ignoreFieldsFlagDescription": "Coma separated list of fields to ignore during dump",
-  "ignoreFieldsConcatenateFlagDescription": "To be used together with -o flag. Concatenates the default list of ignored fields to the list of fields provided in the -o flag.",
+  "ignoreFieldsFlagDescription": "Coma separated list of fields to ignore during dump. To append to the default list of ignored fields add + in the front.",
   "onlyfieldsFlagDescription": "Coma separated list of fields to include in export",
   "idreplacefieldsFlagDescription": "Coma separated list of fields in which SF IDs are replaces by mapped Ids by using text search and replace"
 }

--- a/src/commands/veloce/dump.ts
+++ b/src/commands/veloce/dump.ts
@@ -65,7 +65,6 @@ export default class Org extends SfdxCommand {
       required: true
     }),
     ignorefields: flags.string({char: 'o', description: messages.getMessage('ignoreFieldsFlagDescription')}),
-    ignorefieldsconcatenate: flags.boolean({char: 'C', description: messages.getMessage('ignoreFieldsConcatenateFlagDescription')}),
     idreplacefields: flags.string({char: 'R', description: messages.getMessage('idreplacefieldsFlagDescription'), required: false})
   }
 
@@ -88,11 +87,13 @@ export default class Org extends SfdxCommand {
       }
     }
 
-    const { ignorefields, ignorefieldsconcatenate } = this.flags;
+    const { ignorefields } = this.flags;
     let ignoreFields;
-    const fieldsToIgnore = ignorefields?.split(',');
+    const match = (/(?<appendMode>\+)?\s*(?<fieldsToIgnore>.*)/).exec(ignorefields);
+    const { appendMode, fieldsToIgnore } = match?.groups ?? {};
     if (fieldsToIgnore) {
-      ignoreFields = ignorefieldsconcatenate ?  [...Org.defaultIgnoreFields, ...fieldsToIgnore] : fieldsToIgnore;
+      const fieldsArray = fieldsToIgnore?.split(',');
+      ignoreFields = appendMode ?  [...Org.defaultIgnoreFields, ...fieldsArray] : fieldsArray;
     } else {
       ignoreFields = Org.defaultIgnoreFields;
     }


### PR DESCRIPTION
get rid of -C flag; use + syntax instead for append mode in the -o flag (ignore fields)