### PR TITLE
fix: Packui fixes

### DIFF
--- a/src/commands/veloce/loadmodel.ts
+++ b/src/commands/veloce/loadmodel.ts
@@ -90,9 +90,9 @@ export default class Org extends SfdxCommand {
     // load UI
     const uiDefs: UiDef[] = new UiDefinitionsBuilder('models', name, {}, this.ux).pack()
     try {
-      await axios.post(`${backendUrl}/services/dev-override/model/${name}/ui`, {content: JSON.stringify(uiDefs)}, { headers })
-    } catch ({ data }) {
-      this.ux.log(`Failed to save PML: ${data as string}`)
+      await axios.post(`${backendUrl}/services/dev-override/model/${name}/ui`, { content: JSON.stringify(uiDefs) }, { headers })
+    } catch ({ response }) {
+      this.ux.log(`Failed to save UI: ${response.statusText}. ${response.data.message}`)
       return {}
     }
     this.ux.log('UI Successfully Loaded!')

--- a/src/commands/veloce/packui.ts
+++ b/src/commands/veloce/packui.ts
@@ -15,7 +15,7 @@ const messages = Messages.loadMessages('veloce-sfdx', 'packui')
 export default class Org extends SfdxCommand {
   public static description = messages.getMessage('commandDescription')
 
-  public static examples = ['$ sfdx veloce:packui --inputdir . -n BOARDING --outputfile metadata_new.json']
+  public static examples = ['$ sfdx veloce:packui --inputdir . -n BOARDING --outputfile metadata_new.json -I org-idmap.json']
 
   public static args = [{ name: 'file' }]
 

--- a/src/shared/utils/ui.utils.ts
+++ b/src/shared/utils/ui.utils.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { UX } from '@salesforce/command'
 import { SfdxError } from '@salesforce/core'
 import { IdMap } from '../types/common.types'
@@ -95,7 +95,7 @@ export class UiDefinitionsBuilder {
 
     const element: UiElement = {
       script: toBase64(script),
-      children: metadata.children.map(childName => this.packUiElement(`${dir}/${childName}`))
+      children: metadata.children?.map(childName => this.packUiElement(`${dir}/${childName}`))
     }
 
     const styles = readFileSafe(`${dir}/styles.css`)
@@ -112,12 +112,13 @@ export class UiDefinitionsBuilder {
   }
 
   private packLegacyUiDefinitions(dir: string): LegacyUiDefinition[] {
-    const metadataString = readFileSync(`${dir}/metadata.json`, 'utf-8')
+    const isExistingFile = existsSync(`${dir}/metadata.json`)
 
-    if (!metadataString) {
+    if (!isExistingFile) {
       return []
     }
 
+    const metadataString = readFileSync(`${dir}/metadata.json`, 'utf-8')
     const legacyDefinitions: LegacyUiDefinition[] = JSON.parse(metadataString)
 
     for (const ui of legacyDefinitions) {


### PR DESCRIPTION
1) fix an issue when section meta has no `children` attribute
2) fix an issue when `packui` command would fail if `metadata.json` from the legacy UI definition was missing