### PR TITLE
Reverse id mapping fix

### DIFF
--- a/src/commands/veloce/dump.ts
+++ b/src/commands/veloce/dump.ts
@@ -172,7 +172,7 @@ WHERE EntityDefinition.QualifiedApiName IN ('${this.flags.sobjecttype}') ORDER B
         }
         for (const [key, value] of Object.entries(r)) {
           if (idReplaceFields.includes(key)) {
-            let s = '' + value
+            let s = value ? value.toString() : '';
             for (const [k, v] of Object.entries(reverseIdmap)) {
               const olds = s
               s = olds.replaceAll(k, v as string)


### PR DESCRIPTION
When using -R flag in `dump` command and there is no id to reverse map - use empty string as a value instead of `null`