### PR TITLE
compression flag added to dumpdoc and loaddoc

### DIFF
--- a/messages/dumpdoc.json
+++ b/messages/dumpdoc.json
@@ -1,5 +1,6 @@
 {
   "commandDescription": "Dumps data from Document in org",
   "idFlagDescription": "id of document to dump",
-  "outputfileFlagDescription": "relative/full path to write Document into"
+  "outputfileFlagDescription": "relative/full path to write Document into",
+  "compressionFlagDescription": "compression of dumped Document"
 }

--- a/messages/loaddoc.json
+++ b/messages/loaddoc.json
@@ -4,5 +4,6 @@
   "nameFlagDescription": "name of document to upsert",
   "foldernameFlagDescription": "name of folder to upsert and bind document to",
   "idmapFlagDescription": "idmap.json file path, to store/load <Id:targetId> pairs",
-  "inputfileFlagDescription": "relative/full path to read Document from"
+  "inputfileFlagDescription": "relative/full path to read Document from",
+  "compressionFlagDescription": "compression of dumped Document"
 }

--- a/messages/loaddoc.json
+++ b/messages/loaddoc.json
@@ -5,5 +5,5 @@
   "foldernameFlagDescription": "name of folder to upsert and bind document to",
   "idmapFlagDescription": "idmap.json file path, to store/load <Id:targetId> pairs",
   "inputfileFlagDescription": "relative/full path to read Document from",
-  "compressionFlagDescription": "compression of dumped Document"
+  "compressionFlagDescription": "compression of loaded Document"
 }

--- a/src/commands/veloce/dumpdoc.ts
+++ b/src/commands/veloce/dumpdoc.ts
@@ -37,6 +37,12 @@ export default class Org extends SfdxCommand {
       char: 'o',
       description: messages.getMessage('outputfileFlagDescription'),
       required: true
+    }),
+    compression: flags.string({
+      char: 'c',
+      description: messages.getMessage('compressionFlagDescription'),
+      required: false,
+      default: 'gzip'
     })
   }
 
@@ -70,8 +76,12 @@ export default class Org extends SfdxCommand {
     /* tslint:disable */
     const res = ((await conn.request({ url, encoding: null } as any)) as unknown) as Buffer;
     /* tslint:enable */
-    const gzipped = Buffer.from(res.toString(), 'base64')
-    const data = zlib.gunzipSync(gzipped)
+
+    let data = res;
+    if (this.flags.compression === 'gzip') {
+      data = zlib.gunzipSync(Buffer.from(res.toString(), 'base64'));
+    }
+
     fs.writeFileSync(`${this.flags.outputfile}`, data, {flag: 'w+'})
 
     this.ux.log(`Successfully saved into ${this.flags.outputfile}`)


### PR DESCRIPTION
Added the possibility to skip document compression in order to dump or load image documents.
By default, compression is enabled but can be skipped using `-c` flag.